### PR TITLE
Add floor iv_ squared term in onetouch.

### DIFF
--- a/lib/Math/Business/BlackScholes/Binaries.pm
+++ b/lib/Math/Business/BlackScholes/Binaries.pm
@@ -2,7 +2,7 @@ package Math::Business::BlackScholes::Binaries;
 use strict;
 use warnings;
 
-our $VERSION = '1.2';
+our $VERSION = '1.21';
 
 my $SMALLTIME = 1 / ( 60 * 60 * 24 * 365 );    # 1 second in years;
 
@@ -17,7 +17,7 @@ Math::Business::BlackScholes::Binaries
 
 =head1 VERSION
 
-Version 1.2
+Version 1.21
 
 =head1 SYNOPSIS
 
@@ -286,7 +286,9 @@ sub onetouch {
     my $theta  = ( ($mu) / $sigma ) + ( 0.5 * $sigma );
     my $theta_ = ( ($mu) / $sigma ) - ( 0.5 * $sigma );
 
-    my $v_ = sqrt( ( $theta_ * $theta_ ) + ( 2 * ( 1 - $w ) * $r_q ) );
+    # Floor v_ squared at zero in case negative interest rates push it negative.
+    # See: Barrier Options under Negative Rates in Black-Scholes (Le Floc’h and Pruell, 2014)
+    my $v_ = sqrt( max( 0, ( $theta_ * $theta_ ) + ( 2 * ( 1 - $w ) * $r_q ) ) ) ;
 
     my $e = ( log( $S / $U ) - ( $sigma * $v_ * $t ) ) / ( $sigma * $sqrt_t );
     my $e_ = ( -log( $S / $U ) - ( $sigma * $v_ * $t ) ) / ( $sigma * $sqrt_t );

--- a/t/negative_rate.t
+++ b/t/negative_rate.t
@@ -1,0 +1,25 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib qw{ lib t/lib };
+use Test::Most;
+require Test::NoWarnings;
+use Math::Business::BlackScholes::Binaries;
+use Roundnear;
+
+my $S       = 1.35;
+my $barrier = 1.36;
+my $t       = 7 / 365;
+my $sigma   = 0.11;
+my $r       = -0.005;
+my $q       = -0.002;
+
+my $c;
+lives_ok { $c = Math::Business::BlackScholes::Binaries::onetouch($S, $barrier, $t, $r, $r - $q, $sigma, 0) } 'negative rates one touch does not die';
+cmp_ok(roundnear(0.01, $c), '==', 0.62, 'negative rates onetouch');
+
+Test::NoWarnings::had_no_warnings();
+done_testing();
+


### PR DESCRIPTION
With negative interest rates now more prevalant, we'd rather not die
when they appear in the market.

Barrier Options under Negative Rates in Black-Scholes (Le Floc’h and
Pruell, 2014) offers a solution by going into the complex number space.
Helpfully, they also suggest that flooring this value at zero is a close
enough approximation, so long as the rates don't go wildly negative.

cc: @junbon @rakshit-binary @jy-binary @kavehmz